### PR TITLE
Split histogram classes and into JSON and binary classes

### DIFF
--- a/mysql-test/main/statistics_json.result
+++ b/mysql-test/main/statistics_json.result
@@ -19,7 +19,7 @@ test.t1	analyze	status	Engine-independent statistics collected
 test.t1	analyze	status	OK
 SELECT * FROM mysql.column_stats WHERE table_name='t1';
 db_name	table_name	column_name	min_value	max_value	nulls_ratio	avg_length	avg_frequency	hist_size	hist_type	histogram
-test	t1	a	1	25	0.0000	4.0000	0.0000	10	JSON	[
+test	t1	a	1	25	0.0000	4.0000	1.0000	10	JSON	[
   "3",
   "5",
   "7",
@@ -31,7 +31,7 @@ test	t1	a	1	25	0.0000	4.0000	0.0000	10	JSON	[
   "21",
   "23"
 ]
-test	t1	b	1	9	0.0000	1.6400	0.0000	10	JSON	[
+test	t1	b	1	9	0.0000	1.6400	1.0000	10	JSON	[
   "11",
   "13",
   "15",
@@ -43,7 +43,7 @@ test	t1	b	1	9	0.0000	1.6400	0.0000	10	JSON	[
   "5",
   "7"
 ]
-test	t1	c	1	9	0.0000	2.0000	0.0000	10	JSON	[
+test	t1	c	1	9	0.0000	2.0000	1.0000	10	JSON	[
   "11",
   "13",
   "15",
@@ -55,7 +55,7 @@ test	t1	c	1	9	0.0000	2.0000	0.0000	10	JSON	[
   "5",
   "7"
 ]
-test	t1	d	1	25	0.0000	8.0000	0.0000	10	JSON	[
+test	t1	d	1	25	0.0000	8.0000	1.0000	10	JSON	[
   "3",
   "5",
   "7",
@@ -101,7 +101,7 @@ ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '1'.
 UPDATE mysql.column_stats SET histogram='{}' WHERE table_name='t1';
 FLUSH TABLES;
 SELECT * FROM t1;
-ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '32608'.
+ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '32641'.
 DELETE FROM mysql.column_stats;
 DROP TABLE t1;
 create schema world;

--- a/mysql-test/main/statistics_json.result
+++ b/mysql-test/main/statistics_json.result
@@ -19,7 +19,7 @@ test.t1	analyze	status	Engine-independent statistics collected
 test.t1	analyze	status	OK
 SELECT * FROM mysql.column_stats WHERE table_name='t1';
 db_name	table_name	column_name	min_value	max_value	nulls_ratio	avg_length	avg_frequency	hist_size	hist_type	histogram
-test	t1	a	1	25	0.0000	4.0000	1.0000	10	JSON	[
+test	t1	a	1	25	0.0000	4.0000	0.0000	10	JSON	[
   "3",
   "5",
   "7",
@@ -31,7 +31,7 @@ test	t1	a	1	25	0.0000	4.0000	1.0000	10	JSON	[
   "21",
   "23"
 ]
-test	t1	b	1	9	0.0000	1.6400	1.0000	10	JSON	[
+test	t1	b	1	9	0.0000	1.6400	0.0000	10	JSON	[
   "11",
   "13",
   "15",
@@ -43,7 +43,7 @@ test	t1	b	1	9	0.0000	1.6400	1.0000	10	JSON	[
   "5",
   "7"
 ]
-test	t1	c	1	9	0.0000	2.0000	1.0000	10	JSON	[
+test	t1	c	1	9	0.0000	2.0000	0.0000	10	JSON	[
   "11",
   "13",
   "15",
@@ -55,7 +55,7 @@ test	t1	c	1	9	0.0000	2.0000	1.0000	10	JSON	[
   "5",
   "7"
 ]
-test	t1	d	1	25	0.0000	8.0000	1.0000	10	JSON	[
+test	t1	d	1	25	0.0000	8.0000	0.0000	10	JSON	[
   "3",
   "5",
   "7",

--- a/mysql-test/main/statistics_json.result
+++ b/mysql-test/main/statistics_json.result
@@ -67,6 +67,41 @@ test	t1	d	1	25	0.0000	8.0000	0.0000	10	JSON	[
   "21",
   "23"
 ]
+SELECT * FROM t1;
+a	b	c	d
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	5	5
+6	6	6	6
+7	7	7	7
+8	8	8	8
+9	9	9	9
+10	10	10	10
+11	11	11	11
+12	12	12	12
+13	13	13	13
+14	14	14	14
+15	15	15	15
+16	16	16	16
+17	17	17	17
+18	18	18	18
+19	19	19	19
+20	20	20	20
+21	21	21	21
+22	22	22	22
+23	23	23	23
+24	24	24	24
+25	25	25	25
+UPDATE mysql.column_stats SET histogram='["1", {"a": "b"}, "2"]' WHERE table_name='t1';
+FLUSH TABLES;
+SELECT * FROM t1;
+ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '1'.
+UPDATE mysql.column_stats SET histogram='{}' WHERE table_name='t1';
+FLUSH TABLES;
+SELECT * FROM t1;
+ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '32608'.
 DELETE FROM mysql.column_stats;
 DROP TABLE t1;
 create schema world;

--- a/mysql-test/main/statistics_json.result
+++ b/mysql-test/main/statistics_json.result
@@ -101,7 +101,7 @@ ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '1'.
 UPDATE mysql.column_stats SET histogram='{}' WHERE table_name='t1';
 FLUSH TABLES;
 SELECT * FROM t1;
-ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '32641'.
+ERROR HY000: Failed to parse histogram, encountered JSON_TYPE '1'.
 DELETE FROM mysql.column_stats;
 DROP TABLE t1;
 create schema world;

--- a/mysql-test/main/statistics_json.test
+++ b/mysql-test/main/statistics_json.test
@@ -28,6 +28,19 @@ set histogram_size=10;
 
 ANALYZE TABLE t1 PERSISTENT FOR ALL;
 SELECT * FROM mysql.column_stats WHERE table_name='t1';
+SELECT * FROM t1;
+
+# We then test different valid JSON strings that are invalid histograms.
+UPDATE mysql.column_stats SET histogram='["1", {"a": "b"}, "2"]' WHERE table_name='t1';
+FLUSH TABLES;
+--error ER_JSON_HISTOGRAM_PARSE_FAILED
+SELECT * FROM t1;
+
+UPDATE mysql.column_stats SET histogram='{}' WHERE table_name='t1';
+FLUSH TABLES;
+--error ER_JSON_HISTOGRAM_PARSE_FAILED
+SELECT * FROM t1;
+
 DELETE FROM mysql.column_stats;
 DROP TABLE t1;
 

--- a/sql/field.h
+++ b/sql/field.h
@@ -1852,6 +1852,7 @@ public:
   {
     return (double) 0.5; 
   }
+  virtual bool pos_through_val_str() { return false;}
 
   /*
     Check if comparison between the field and an item unambiguously
@@ -2137,6 +2138,8 @@ public:
   {
     return pos_in_interval_val_str(min, max, length_size());
   }
+  bool pos_through_val_str() override {return true;}
+
   bool test_if_equality_guarantees_uniqueness(const Item *const_item) const
     override;
   SEL_ARG *get_mm_leaf(RANGE_OPT_PARAM *param, KEY_PART *key_part,

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7992,3 +7992,5 @@ ER_REMOVED_ORPHAN_TRIGGER
         eng "Dropped orphan trigger '%-.64s', originally created for table: '%-.192s'"
 ER_STORAGE_ENGINE_DISABLED
         eng "Storage engine %s is disabled"
+ER_JSON_HISTOGRAM_PARSE_FAILED
+        eng "Failed to parse histogram, encountered JSON_TYPE '%d'."

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -1086,7 +1086,7 @@ public:
           // Note: this is dumb. the histogram size is stored with the
           // histogram!
           stat_field->store(stats->histogram_? 
-                              stats->histogram_->get_size() : 0);
+                              stats->histogram_->get_width() : 0);
           break;
         case COLUMN_STAT_HIST_TYPE:
           if (stats->histogram_)
@@ -1256,7 +1256,6 @@ bool Histogram_binary::parse(MEM_ROOT *mem_root, Histogram_type type_arg, const 
   return false;
 }
 
-
 /*
   Save the histogram data info a table field.
 */
@@ -1268,7 +1267,7 @@ void Histogram_binary::serialize(Field *field)
                  &my_charset_bin);
   }
   else
-    field->store((char*)get_values(), get_size(), &my_charset_bin);
+    field->store((char*)get_values(), get_width(), &my_charset_bin);
 }
 
 void Histogram_binary::init_for_collection(MEM_ROOT *mem_root,
@@ -1287,6 +1286,7 @@ void Histogram_json::init_for_collection(MEM_ROOT *mem_root, Histogram_type htyp
   values = (uchar*)alloc_root(mem_root, size_arg);
   size = (uint8) size_arg;
 }
+
 /*
   An object of the class Index_stat is created to read statistical
   data on tables from the statistical table table_stat, to update
@@ -2641,18 +2641,19 @@ bool Column_statistics_collected::add()
 
 
 /* 
-  Create an empty Histogram_binary object from histogram_type.
+  Create an empty Histogram object from histogram_type.
 
   Note: it is not yet clear whether collection-time histogram should be the same 
   as lookup-time histogram. At the moment, they are.
 */
 
-Histogram_binary * get_histogram_by_type(MEM_ROOT *mem_root, Histogram_type hist_type) {
+Histogram_base * get_histogram_by_type(MEM_ROOT *mem_root, Histogram_type hist_type) {
   switch (hist_type) {
   case SINGLE_PREC_HB:
   case DOUBLE_PREC_HB:
-  case JSON:
     return new Histogram_binary();
+  case JSON:
+    return new Histogram_json();
   default:
     DBUG_ASSERT(0);
   }

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -1993,11 +1993,10 @@ bool json_get_array_items(const char *json, const char *json_end, int *value_typ
 
   json_scan_start(&je, &my_charset_utf8mb4_bin, (const uchar *)json, (const uchar *)json_end);
 
-  if (json_read_value(&je) || je.value_type != JSON_VALUE_ARRAY)
+  if (json_read_value(&je) || (*value_type = je.value_type) != JSON_VALUE_ARRAY)
   {
     return false;
   }
-  *value_type = je.value_type;
 
   std::string val;
   while(!json_scan_next(&je))

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -1283,7 +1283,6 @@ void Histogram_json::init_for_collection(MEM_ROOT *mem_root, Histogram_type htyp
 
 bool Histogram_json::parse(MEM_ROOT *mem_root, Histogram_type type_arg, const uchar *ptr, uint size_arg)
 {
-  size = (uint8) size_arg;
   type = type_arg;
   // I think we could use memcpy here, but not sure about how to get the right size
   // since we can't depend on size_arg (it's zero for json histograms)
@@ -1303,7 +1302,7 @@ bool Histogram_json::parse(MEM_ROOT *mem_root, Histogram_type type_arg, const uc
 
 void Histogram_json::serialize(Field *field)
 {
-  field->store((char*)get_values(), strlen((char*)get_values()),
+  field->store((char*)values, strlen((char*)values),
                &my_charset_bin);
 }
 

--- a/sql/sql_statistics.h
+++ b/sql/sql_statistics.h
@@ -372,9 +372,9 @@ public:
            is_available();
   }
 
-  void set_values (uchar *vals) override { values= (uchar *) vals; }
+  void set_values (uchar *vals) override { values= vals; }
 
-  uchar *get_values() override { return (uchar *) values; }
+  uchar *get_values() override { return values; }
 
   double range_selectivity(double min_pos, double max_pos) override {return 0.1;}
 

--- a/sql/sql_statistics.h
+++ b/sql/sql_statistics.h
@@ -171,11 +171,6 @@ public:
   virtual double range_selectivity(double min_pos, double max_pos)=0;
 
   virtual double point_selectivity(double pos, double avg_selection)=0;
-  
-  // Legacy: return the size of the histogram on disk.
-  // This will be stored in mysql.column_stats.hist_size column.
-  // Newer, JSON-based histograms may return 0.
-  virtual uint get_size()=0;
 
   virtual ~Histogram_base(){}
 };
@@ -188,8 +183,6 @@ public:
   void serialize(Field *to_field) override;
 
   Histogram_type get_type() override { return type; }
-
-  uint get_size() override { return (uint) size; }
 
   uint get_width() override
   {
@@ -283,7 +276,7 @@ public:
   void set_values (uchar *vals) override { values= (uchar *) vals; }
   void set_size (ulonglong sz) override { size= (uint8) sz; }
 
-  bool is_available() override { return get_size() > 0 && get_values(); }
+  bool is_available() override { return get_width() > 0 && get_values(); }
 
   /*
     This function checks that histograms should be usable only when
@@ -354,8 +347,6 @@ public:
 
   void serialize(Field *to_field) override{}
 
-  uint get_size() override {return (uint) size;}
-
   // returns number of buckets in the histogram
   uint get_width() override
   {
@@ -371,7 +362,7 @@ public:
 
   void init_for_collection(MEM_ROOT *mem_root, Histogram_type htype_arg, ulonglong size) override;
 
-  bool is_available() override {return get_size() > 0 && get_values(); }
+  bool is_available() override {return get_width() > 0 && get_values(); }
 
   bool is_usable(THD *thd) override
   {

--- a/sql/sql_statistics.h
+++ b/sql/sql_statistics.h
@@ -16,6 +16,7 @@
 #ifndef SQL_STATISTICS_H
 #define SQL_STATISTICS_H
 
+#include <vector>
 /*
   For COMPLEMENTARY_FOR_QUERIES and PREFERABLY_FOR_QUERIES they are
   similar to the COMPLEMENTARY and PREFERABLY respectively except that
@@ -341,11 +342,12 @@ private:
   Histogram_type type;
   uint8 size; /* Number of elements in the histogram*/
   uchar *values;
+  std::vector<std::string> hist_buckets;
 
 public:
-  bool parse(MEM_ROOT *mem_root, Histogram_type type_arg, const uchar *ptr, uint size) override {return false;}
+  bool parse(MEM_ROOT *mem_root, Histogram_type type_arg, const uchar *ptr, uint size) override;
 
-  void serialize(Field *to_field) override{}
+  void serialize(Field *field) override;
 
   // returns number of buckets in the histogram
   uint get_width() override


### PR DESCRIPTION
Ongoing patch for milestone #4, this splits up the histogram base class into `Histogram_binary` and `Histogram_json`. A question though:
- The code that differs between `Histogram_builder_json` and `Histogram_builder` isn't much (just the `next` implementation), does it make sense to unify them and just reference `Histogram_base`?

Also, the code builds and seems to work fine with building JSON from histograms (by inspecting `mysqld.1.err` at least), but it messes up storing the JSON structure in the table - I'm not sure why that's happening at the moment.